### PR TITLE
Add Tournament 2025 Champion section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-debug.log*
 yarn-error.log*
 app.log
 .nvmrc
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ npm run test:coverage  # Generate coverage report
 ```
 
 Run a single test file:
+
 ```bash
 npx vitest run src/test/components/SimpleLeaderboard.test.jsx
 ```
@@ -29,9 +30,11 @@ npx vitest run src/test/components/SimpleLeaderboard.test.jsx
 **Data flow**: `src/data/games.json` → `src/utils/dataUtils.js` (processing/calculations) → components (display only).
 
 **Entry points**:
+
 - `index.html` → `src/index.jsx` (wraps app in `ThemeProvider` + i18next `Suspense`) → `src/App.jsx` (single page with all sections, each wrapped in an `ErrorBoundary`)
 
 **Key utilities**:
+
 - `src/utils/dataUtils.js` — all game data calculations (scores, rankings, team resolution)
 - `src/utils/ThemeContext.jsx` — dark/light theme context (persisted to localStorage, respects `prefers-color-scheme`)
 - `src/utils/i18n.js` — i18next setup with browser language detection, fallback: Danish (`da`)
@@ -57,6 +60,7 @@ Avatars live in `public/avatars/`. Two contexts, each with variations:
 ## UI Components
 
 All components render on a single page in this order:
+
 1. `SimpleSummaryCards` — current leader, best team, game stats
 2. `SimpleLeaderboard` — player rankings with avatars, scores, averages, win ratio
 3. `SimplePlayerPerformance` — per-player metrics across games

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+A single-page React application for visualizing gaming tournament statistics for a card game called "partners". Built with React 18 + Vite, deployed on Digital Ocean App Platform.
+
+## Commands
+
+```bash
+npm start          # Dev server on port 3000 (auto-opens browser)
+npm run build      # Production build to /build
+npm run preview    # Preview production build locally
+
+npm test           # Watch mode (interactive)
+npm run test:run   # Run tests once
+npm run test:ui    # Vitest UI dashboard
+npm run test:coverage  # Generate coverage report
+```
+
+Run a single test file:
+```bash
+npx vitest run src/test/components/SimpleLeaderboard.test.jsx
+```
+
+## Architecture
+
+**Data flow**: `src/data/games.json` → `src/utils/dataUtils.js` (processing/calculations) → components (display only).
+
+**Entry points**:
+- `index.html` → `src/index.jsx` (wraps app in `ThemeProvider` + i18next `Suspense`) → `src/App.jsx` (single page with all sections, each wrapped in an `ErrorBoundary`)
+
+**Key utilities**:
+- `src/utils/dataUtils.js` — all game data calculations (scores, rankings, team resolution)
+- `src/utils/ThemeContext.jsx` — dark/light theme context (persisted to localStorage, respects `prefers-color-scheme`)
+- `src/utils/i18n.js` — i18next setup with browser language detection, fallback: Danish (`da`)
+- `src/utils/logger.js` — Logtail wrapper (fails gracefully if `VITE_LOGTAIL_KEY` is absent)
+
+**Test setup** (`src/test/setup.js`) mocks: `window.matchMedia`, logger, `IntersectionObserver`, `ResizeObserver`. Tests in `src/test/development/` and `src/test/manual/` are excluded from the test runner.
+
+## Game Domain Model
+
+- 6 players: Jonas, Torben, Gitte, Anette, Lotte, Peter
+- Each game has 3 teams of 2 players (all 6 players participate in every game)
+- Scoring: 1st place = 3 pts, 2nd = 2 pts, 3rd = 1 pt
+- Teams are resolved from `games.json` by grouping players with the same score per game
+
+## Avatar System
+
+Avatars live in `public/avatars/`. Two contexts, each with variations:
+
+- **Ranking context** (3 variations): happy (1st), neutral (2nd–3rd), sad (4th+)
+- **Game outcome context** (2 variations): happy (win/1st), neutral (2nd), sad (loss/3rd)
+- **Team statistics**: happy (1st–3rd), neutral (4th–9th), sad (10th+)
+
+## UI Components
+
+All components render on a single page in this order:
+1. `SimpleSummaryCards` — current leader, best team, game stats
+2. `SimpleLeaderboard` — player rankings with avatars, scores, averages, win ratio
+3. `SimplePlayerPerformance` — per-player metrics across games
+4. `SimpleGamesCalendar` — game count, game days, activity timeline, recent games
+5. `SimpleTeamStatistics` — team performance, win rates, rankings
+6. `SimpleGamesList` — recent game outcomes with teams and scores
+
+## Environment Variables
+
+- `VITE_LOGTAIL_KEY` — Logtail API token (optional; logging silently disabled without it)
+- `.env.test` used for test runs
+
+## Node Version
+
+Use Node v22 (see `.nvmrc`). CI tests against Node 20.x and 22.x.
+
+## Documentation
+
+New documentation goes in `docs/` (not the root). Markdown must pass markdownlint rules defined in `.markdownlint.json`.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import SimpleSummaryCards from './components/SimpleSummaryCards';
 import SimpleTeamStatistics from './components/SimpleTeamStatistics';
 import SimplePlayerPerformance from './components/SimplePlayerPerformance';
 import SimpleGamesCalendar from './components/SimpleGamesCalendar';
+import TournamentChampion2025 from './components/TournamentChampion2025';
 import LanguageSelector from './components/LanguageSelector';
 import ErrorBoundary from './components/ErrorBoundary';
 import { useTranslation } from 'react-i18next';
@@ -75,6 +76,11 @@ function App() {
       </nav>
       
       <div className="container">
+        {/* Tournament 2025 Final Results */}
+        <ErrorBoundary name="TournamentChampion2025">
+          <TournamentChampion2025 />
+        </ErrorBoundary>
+
         {/* First row: Summary Cards (Current leader, Best team, Game statistics) */}
         <ErrorBoundary name="SummaryCards">
           <SimpleSummaryCards />

--- a/src/components/TournamentChampion2025.jsx
+++ b/src/components/TournamentChampion2025.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { getLeaderboardData, getGames, getTeamStatistics } from '../utils/dataUtils';
+import SimpleAvatarWithHover from './SimpleAvatarWithHover';
+import { getRankBasedAvatar } from '../utils/simpleAvatarUtils';
+
+const TournamentChampion2025 = () => {
+  const { t } = useTranslation();
+
+  let champion = null;
+  let bestTeam = null;
+  let totalGames = 0;
+  let dateRange = null;
+  let dataError = null;
+
+  try {
+    const { players } = getLeaderboardData();
+    const games = getGames();
+    const teamStats = getTeamStatistics();
+
+    champion = players.length > 0 ? players[0] : null;
+    bestTeam = teamStats.length > 0 ? teamStats[0] : null;
+    totalGames = games.length;
+
+    if (games.length > 0) {
+      const dates = games.map(g => g.gameDate).sort();
+      dateRange = { start: dates[0], end: dates[dates.length - 1] };
+    }
+  } catch (error) {
+    console.error('Error loading tournament data:', error);
+    dataError = error.message;
+  }
+
+  if (dataError) {
+    return (
+      <div className="alert alert-danger mb-4">
+        <strong>{t('tournament2025.noData')}:</strong> {dataError}
+      </div>
+    );
+  }
+
+  if (!champion || !bestTeam) {
+    return null;
+  }
+
+  return (
+    <div className="card border-warning mb-4" style={{ background: 'var(--bs-warning-bg-subtle, #fff9e6)' }}>
+      <div className="card-header bg-warning text-dark text-center py-3">
+        <h2 className="mb-1 fw-bold">{t('tournament2025.title')}</h2>
+        <div className="d-flex justify-content-center align-items-center gap-3 flex-wrap">
+          <span className="badge bg-dark fs-6">{t('tournament2025.concluded')}</span>
+          {dateRange && (
+            <span className="text-dark">
+              {t('tournament2025.dateRange', { start: dateRange.start, end: dateRange.end })}
+            </span>
+          )}
+          <span className="text-dark fw-semibold">
+            {t('tournament2025.totalGames', { count: totalGames })}
+          </span>
+        </div>
+      </div>
+
+      <div className="card-body">
+        <div className="row g-4 justify-content-center">
+
+          {/* Champion */}
+          <div className="col-md-5">
+            <div className="card h-100 border-success text-center shadow-sm">
+              <div className="card-header bg-success text-white">
+                <h4 className="mb-0">🏆 {t('tournament2025.champion')}</h4>
+              </div>
+              <div className="card-body d-flex flex-column align-items-center justify-content-center py-4">
+                <div className="mb-3">
+                  <SimpleAvatarWithHover
+                    playerName={champion.name}
+                    avatarSrc={getRankBasedAvatar(champion.name, 1)}
+                    size={90}
+                  />
+                </div>
+                <h3 className="text-success fw-bold mb-2">{champion.name}</h3>
+                <div className="display-5 text-success fw-bold mb-1">
+                  {champion.cumulativeScore}
+                </div>
+                <div className="text-muted mb-3">{t('tournament2025.points')}</div>
+                <div className="d-flex gap-4 text-center">
+                  <div>
+                    <div className="h5 text-success mb-0">{champion.wins}</div>
+                    <small className="text-muted">{t('tournament2025.wins')}</small>
+                  </div>
+                  <div>
+                    <div className="h5 text-success mb-0">{(champion.winRate || 0).toFixed(1)}%</div>
+                    <small className="text-muted">{t('tournament2025.winRate')}</small>
+                  </div>
+                  <div>
+                    <div className="h5 text-success mb-0">{champion.gamesPlayed}</div>
+                    <small className="text-muted">{t('tournament2025.gamesPlayed')}</small>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Best Team */}
+          <div className="col-md-5">
+            <div className="card h-100 border-warning text-center shadow-sm">
+              <div className="card-header bg-warning text-dark">
+                <h4 className="mb-0">🥇 {t('tournament2025.bestTeam')}</h4>
+              </div>
+              <div className="card-body d-flex flex-column align-items-center justify-content-center py-4">
+                <div className="mb-3 d-flex gap-3 justify-content-center">
+                  {bestTeam.players.map((player, idx) => (
+                    <SimpleAvatarWithHover
+                      key={idx}
+                      playerName={player}
+                      avatarSrc={getRankBasedAvatar(player, 1)}
+                      size={90}
+                    />
+                  ))}
+                </div>
+                <h3 className="text-warning fw-bold mb-2">{bestTeam.players.join(' & ')}</h3>
+                <div className="display-5 text-warning fw-bold mb-1">
+                  {bestTeam.wins}
+                </div>
+                <div className="text-muted mb-3">{t('tournament2025.wins')}</div>
+                <div className="d-flex gap-4 text-center">
+                  <div>
+                    <div className="h5 text-warning mb-0">{bestTeam.totalPoints}</div>
+                    <small className="text-muted">{t('tournament2025.points')}</small>
+                  </div>
+                  <div>
+                    <div className="h5 text-warning mb-0">{(bestTeam.winRate || 0).toFixed(1)}%</div>
+                    <small className="text-muted">{t('tournament2025.winRate')}</small>
+                  </div>
+                  <div>
+                    <div className="h5 text-warning mb-0">{bestTeam.gamesPlayed}</div>
+                    <small className="text-muted">{t('tournament2025.gamesPlayed')}</small>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TournamentChampion2025;

--- a/src/components/TournamentChampion2025.jsx
+++ b/src/components/TournamentChampion2025.jsx
@@ -7,29 +7,39 @@ import { getRankBasedAvatar } from '../utils/simpleAvatarUtils';
 const TournamentChampion2025 = () => {
   const { t } = useTranslation();
 
-  let champion = null;
-  let bestTeam = null;
-  let totalGames = 0;
-  let dateRange = null;
-  let dataError = null;
+  const { champion, bestTeam, totalGames, dateRange, dataError } = React.useMemo(() => {
+    try {
+      const leaderboardData = getLeaderboardData();
+      const players = leaderboardData.players || [];
+      const games = leaderboardData.games || getGames();
+      const teamStats = getTeamStatistics();
 
-  try {
-    const { players } = getLeaderboardData();
-    const games = getGames();
-    const teamStats = getTeamStatistics();
+      let computedDateRange = null;
 
-    champion = players.length > 0 ? players[0] : null;
-    bestTeam = teamStats.length > 0 ? teamStats[0] : null;
-    totalGames = games.length;
+      if (games.length > 0) {
+        const dates = games.map(g => g.gameDate).sort();
+        computedDateRange = { start: dates[0], end: dates[dates.length - 1] };
+      }
 
-    if (games.length > 0) {
-      const dates = games.map(g => g.gameDate).sort();
-      dateRange = { start: dates[0], end: dates[dates.length - 1] };
+      return {
+        champion: players.length > 0 ? players[0] : null,
+        bestTeam: teamStats.length > 0 ? teamStats[0] : null,
+        totalGames: games.length,
+        dateRange: computedDateRange,
+        dataError: null
+      };
+    } catch (error) {
+      console.error('Error loading tournament data:', error);
+
+      return {
+        champion: null,
+        bestTeam: null,
+        totalGames: 0,
+        dateRange: null,
+        dataError: error.message
+      };
     }
-  } catch (error) {
-    console.error('Error loading tournament data:', error);
-    dataError = error.message;
-  }
+  }, []);
 
   if (dataError) {
     return (

--- a/src/components/TournamentChampion2025.jsx
+++ b/src/components/TournamentChampion2025.jsx
@@ -118,9 +118,9 @@ const TournamentChampion2025 = () => {
               </div>
               <div className="card-body d-flex flex-column align-items-center justify-content-center py-4">
                 <div className="mb-3 d-flex gap-3 justify-content-center">
-                  {bestTeam.players.map((player, idx) => (
+                  {bestTeam.players.map((player) => (
                     <SimpleAvatarWithHover
-                      key={idx}
+                      key={player}
                       playerName={player}
                       avatarSrc={getRankBasedAvatar(player, 1)}
                       size={90}

--- a/src/test/components/TournamentChampion2025.test.jsx
+++ b/src/test/components/TournamentChampion2025.test.jsx
@@ -48,8 +48,8 @@ describe('TournamentChampion2025 Component', () => {
 
   it('displays the total game count', () => {
     renderWithProviders(<TournamentChampion2025 />);
-    // The translation for totalGames renders "2 games played"
-    expect(screen.getByText(/2/)).toBeInTheDocument();
+    // The da translation for tournament2025.totalGames renders "2 spil spillet"
+    expect(screen.getByText(/2 spil spillet/)).toBeInTheDocument();
   });
 
   it('displays the champion cumulative score', () => {

--- a/src/test/components/TournamentChampion2025.test.jsx
+++ b/src/test/components/TournamentChampion2025.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../utils/ThemeContext';
+import '../../utils/i18n';
+import TournamentChampion2025 from '../../components/TournamentChampion2025';
+
+vi.mock('../../utils/dataUtils', () => ({
+  getLeaderboardData: () => ({
+    players: [
+      { id: 1, name: 'Jonas', cumulativeScore: 42, wins: 14, winRate: 70.0, gamesPlayed: 20 },
+      { id: 2, name: 'Torben', cumulativeScore: 36, wins: 10, winRate: 50.0, gamesPlayed: 20 }
+    ]
+  }),
+  getGames: () => [
+    { gameId: 1, gameDate: '2025-04-12', teams: [] },
+    { gameId: 2, gameDate: '2025-11-30', teams: [] }
+  ],
+  getTeamStatistics: () => [
+    { players: ['Jonas', 'Gitte'], wins: 8, totalPoints: 52, gamesPlayed: 12, winRate: 66.7 },
+    { players: ['Torben', 'Anette'], wins: 5, totalPoints: 38, gamesPlayed: 12, winRate: 41.7 }
+  ]
+}));
+
+const renderWithProviders = (component) => {
+  return render(
+    <ThemeProvider>
+      {component}
+    </ThemeProvider>
+  );
+};
+
+describe('TournamentChampion2025 Component', () => {
+  it('renders without crashing', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    const container = document.querySelector('.card');
+    expect(container).toBeInTheDocument();
+  });
+
+  it('displays the champion player name', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    expect(screen.getByText('Jonas')).toBeInTheDocument();
+  });
+
+  it('displays the best team player names', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    expect(screen.getByText('Jonas & Gitte')).toBeInTheDocument();
+  });
+
+  it('displays the total game count', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    // The translation for totalGames renders "2 games played"
+    expect(screen.getByText(/2/)).toBeInTheDocument();
+  });
+
+  it('displays the champion cumulative score', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('displays avatar elements for champion and team', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    // SimpleAvatarWithHover renders img tags; champion + 2 team members = 3 avatars
+    const avatars = document.querySelectorAll('img');
+    expect(avatars.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('displays the date range', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    expect(screen.getByText(/2025-04-12/)).toBeInTheDocument();
+    expect(screen.getByText(/2025-11-30/)).toBeInTheDocument();
+  });
+
+  it('has Bootstrap card structure', () => {
+    renderWithProviders(<TournamentChampion2025 />);
+    const cards = document.querySelectorAll('.card');
+    expect(cards.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/locales/da.js
+++ b/src/utils/locales/da.js
@@ -303,6 +303,19 @@ export default {
       "noGames": "Ingen seneste spil"
     }
   },
+  "tournament2025": {
+    "title": "Partners Turnering 2025 — Slutresultater",
+    "concluded": "Turnering Afsluttet",
+    "dateRange": "{{start}} – {{end}}",
+    "totalGames": "{{count}} spil spillet",
+    "champion": "Mester",
+    "bestTeam": "Bedste Hold",
+    "points": "point",
+    "wins": "sejre",
+    "winRate": "sejrs rate",
+    "gamesPlayed": "spil spillet",
+    "noData": "Ingen turnerings data tilgængelig"
+  },
   "charts": {
     "playerStats": {
       "title": "Spillerstatistik",

--- a/src/utils/locales/en.js
+++ b/src/utils/locales/en.js
@@ -303,6 +303,19 @@ export default {
       "noGames": "No recent games"
     }
   },
+  "tournament2025": {
+    "title": "Partners Tournament 2025 — Final Results",
+    "concluded": "Tournament Concluded",
+    "dateRange": "{{start}} – {{end}}",
+    "totalGames": "{{count}} games played",
+    "champion": "Champion",
+    "bestTeam": "Best Team",
+    "points": "points",
+    "wins": "wins",
+    "winRate": "win rate",
+    "gamesPlayed": "games played",
+    "noData": "No tournament data available"
+  },
   "charts": {
     "playerStats": {
       "title": "Player Statistics",


### PR DESCRIPTION
## Summary

- Adds a `TournamentChampion2025` hero banner component rendered at the top of the page, above the existing summary cards
- Displays the winning player (name, happy avatar, total points, wins, win rate, games played) and best team (names, happy avatars, wins, total points, win rate, games played) derived from the tournament-concluded 2025 data
- Shows tournament date range and total game count in the banner header
- Adds `tournament2025` i18n namespace to both English and Danish locale files
- Wraps the component in an `ErrorBoundary` in `App.jsx` following the existing pattern
- Adds a component smoke-test in `src/test/components/TournamentChampion2025.test.jsx`

## Notes

All data comes from existing `getLeaderboardData()`, `getGames()`, and `getTeamStatistics()` utilities — no new data processing was needed. The pre-existing `ERR_REQUIRE_ESM` test runner error (jsdom / `@exodus/bytes` conflict) affects the entire test suite and is unrelated to this change; the production build compiles cleanly.

## Test plan

- [ ] Build succeeds: `npm run build`
- [ ] Champion banner appears at top of page with correct player name and score
- [ ] Best team banner shows both player names and happy avatars
- [ ] Date range and game count display correctly
- [ ] Dark/light theme toggle applies correctly to the new section
- [ ] Language toggle switches between English and Danish labels
- [ ] If data loading fails, the ErrorBoundary catches it gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)