### PR TITLE
fix: three bug fixes from TODO.md (total games, i18n namespace, avatar rank)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,89 @@
+# TODO
+
+Improvements identified from a codebase review on 2026-06-12.
+
+## Bugs
+
+- [x] **Wrong total-games calculation in `SimpleLeaderboard`** (`src/components/SimpleLeaderboard.jsx:164`) — footer divides the sum of all player `gamesPlayed` by 2, but there are 6 players per game, so it inflates the count by 3×. Should divide by 6 or use `leaderboardData.games.length` directly (already available from `getLeaderboardData`).
+
+- [x] **`SimpleGamesCalendar` uses wrong i18n namespace** (`src/components/SimpleGamesCalendar.jsx:28,43,44`) — error and empty-state messages call `t('gamesList.errorLoading')`, `t('gamesList.noGames')`, and `t('gamesList.startPlaying')`, which belong to the `gamesList` component. These should use `gamesCalendar.*` keys.
+
+- [x] **Team avatar logic doesn't match spec** (`src/components/SimpleTeamStatistics.jsx:108`) — the component maps rank ≤ 3 → happy, rank ≥ 4 → sad. The spec requires: happy (1st–3rd), neutral (4th–9th), sad (10th+). `getRankBasedAvatar` also treats rank 4+ as sad regardless, so it cannot express the neutral range for team standings.
+
+## Code Quality
+
+- [ ] **36 debug `console.log` calls in production code** — scattered across `SimpleLeaderboard`, `SimpleTeamStatistics`, `SimpleSummaryCards`, `SimplePlayerPerformance`, `SimpleAvatarWithHover`, `SimpleGamesCalendar`, `SimpleThemeToggle`, and `simpleAvatarUtils.js`. Remove or route through the `Logger` utility.
+
+- [ ] **`processGamesData` called 3× per render in `SimpleSummaryCards`** — `getLeaderboardData`, `getGames`, and `getTeamStatistics` each independently call `processGamesData`, resulting in three full passes through the game data per render. The component should call `processGamesData` once and derive all three results, or the utilities should accept pre-processed data.
+
+- [ ] **`TournamentChampion2025` has a redundant `getGames` call** (`src/components/TournamentChampion2025.jsx:14`) — `getLeaderboardData` already returns `{ players, games }`, so the separate `getGames` call triggers a second `processGamesData` pass unnecessarily.
+
+- [ ] **Player roster hardcoded in two places** in `dataUtils.js` — the 6-player array appears once in `processGamesData` (lines 13–21) and again as `allPlayers` in `getTeamCombinationStatistics` (line 162). Extract to a single exported constant.
+
+- [ ] **`getPerformanceBasedAvatar` is a deprecated no-op** (`src/utils/simpleAvatarUtils.js:128`) — only fires a `console.warn` then delegates to `getRankBasedAvatar`. Remove it along with any test references.
+
+- [ ] **`leaderboard.json` is dead code** (`src/data/leaderboard.json`) — contains zeroed-out player data and is never imported anywhere.
+
+- [ ] **`summary.*` i18n namespace is orphaned** — both locale files define a `summary` top-level namespace (`leadingPlayer`, `mostWinningTeam`, `teamCoverage`, etc.) that no component uses; components use `summaryCards.*` instead. These keys are only referenced in two test files. Rename to match component usage or remove.
+
+- [ ] **No ESLint configuration** — the quality CI workflow already acknowledges the gap. Adding `eslint` with `eslint-plugin-react` and `eslint-plugin-react-hooks` would catch most of the issues above automatically.
+
+## Test Coverage
+
+- [ ] **Five components have no dedicated test files**: `SimpleGamesCalendar`, `SimpleGamesList`, `SimplePlayerPerformance`, `SimpleTeamStatistics`, `SimpleAvatarWithHover`.
+
+- [ ] **`src/test/utilities.test.js` reimplements `getPlayerAvatarPath` inline** instead of importing from `simpleAvatarUtils`. It calls the reimplemented version with two arguments, which the real function does not accept, so the tests are not exercising the actual code.
+
+## Accessibility
+
+- [ ] **Progress bars lack ARIA attributes** — `SimpleSummaryCards` and `SimplePlayerPerformance` render `<div class="progress-bar">` without `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, or `aria-valuemax`. Bootstrap requires these for screen reader support.
+
+- [ ] **Data tables have no `<caption>`** — `SimpleLeaderboard` and `SimpleTeamStatistics` render `<table>` elements without a caption, which screen readers need to identify the table's purpose.
+
+## Architecture / Maintainability
+
+- [ ] **Date formatting is locale-independent** — `formatDate` in `SimpleGamesCalendar` and `SimpleGamesList` hardcodes `dd/mm/yyyy`. It should use `toLocaleDateString` with the active i18n locale or a locale-aware format string.
+
+- [ ] **`TournamentChampion2025` is year-specific** — when a future tournament concludes, a new component would need to be created by hand. A single generic `TournamentChampion` component parameterised by year would avoid this.
+
+## Documentation
+
+Findings from a documentation review on 2026-06-12.
+
+### Security
+
+- [ ] **`docs/LOGGING.md` contains the Logtail ingestion token in plain text** (line 7) — `gDcpojWzsEzzJVpXTyjAFsPF` is committed verbatim. Remove it from the file and rotate the token.
+
+### Accuracy
+
+- [ ] **Root `README.md` is entirely CRA boilerplate** — describes none of the actual project, references `npm run eject` (Vite project), and describes `npm test` as interactive watch mode. Replace with a project-specific README covering what the app does, commands, and how to deploy.
+
+- [ ] **`docs/README.md` lists wrong versions** — states React 19.2.0 and Vite 6.4.1; actual versions per `package.json` are React 18.3.1 and Vite 8.x. Also lists `@nivo` as a dependency, which was removed.
+
+- [ ] **`docs/README.md` index is incomplete** — `TODO.md` and `security-review-baseline-2026-06-12.md` are not listed.
+
+- [ ] **`docs/LOGGING.md` references outdated filenames** — lists `App.js`, `ThemeToggle.js`, `AvatarWithHover.js`, `GamesList.js`; actual names are `App.jsx`, `SimpleThemeToggle.jsx`, `SimpleAvatarWithHover.jsx`, `SimpleGamesList.jsx`.
+
+- [ ] **`docs/Z_INDEX_DOCUMENTATION.md` references outdated filenames throughout** — `AvatarWithHover.js`, `GamesList.js`, `SummaryCards.js` should be `SimpleAvatarWithHover.jsx`, `SimpleGamesList.jsx`, `SimpleSummaryCards.jsx`. Also contains a dangling code block and references z-index `10015` without defining it in the hierarchy.
+
+- [ ] **`docs/TESTING.md` has minor inaccuracies** — describes `npm test` as watch mode; advises skipping @nivo tests (library was removed); example code calls `getPlayerAvatarPath` with two arguments but the function only accepts one.
+
+### Obsolete documents
+
+- [ ] **`docs/DEPLOYMENT.md`** — documents the @nivo white-page incident, which is resolved. References components that no longer exist (`ChartErrorBoundary.jsx`, `RobustCalendarChart.jsx`, `LazyCharts.jsx`). Archive or convert to an ADR.
+
+- [ ] **`docs/DEPLOYMENT_FINAL.md`** — documents the resolution of the same @nivo incident. References non-existent components. Archive or convert to an ADR.
+
+- [ ] **`docs/EMERGENCY_FIX.md`** — run-book for a resolved incident. Misleads readers into thinking the app is unstable and that committing `build/` is normal practice. Remove or archive.
+
+- [ ] **`docs/TESTING_EVALUATION.md`** — recommends migrating test files that are already migrated. Content is superseded by current state. Review and either update to reflect current state or remove.
+
+### Missing SDLC documentation
+
+- [ ] **No project README** — replace the CRA boilerplate with a README covering: what "partners" is, who the players are, the scoring rules, how to run locally, how to deploy, and how to add a new year of data.
+
+- [ ] **No deployment guide** — no document describes how to deploy to Digital Ocean App Platform (build command, env vars to set, how to trigger a deploy).
+
+- [ ] **No data update guide** — adding a new game result or a new tournament year requires code changes; this process is not documented anywhere.
+
+- [ ] **No contributing guide** — no PR conventions, branch strategy, commit style, or review process documented.

--- a/src/components/SimpleGamesCalendar.jsx
+++ b/src/components/SimpleGamesCalendar.jsx
@@ -25,7 +25,7 @@ const SimpleGamesCalendar = ({ gameData }) => {
         </div>
         <div className="card-body">
           <div className="alert alert-danger">
-            <strong>{t('gamesList.errorLoading')}:</strong> {dataError}
+            <strong>{t('gamesCalendar.errorLoading')}:</strong> {dataError}
           </div>
         </div>
       </div>
@@ -40,8 +40,8 @@ const SimpleGamesCalendar = ({ gameData }) => {
         </div>
         <div className="card-body">
           <div className="alert alert-info">
-            <h4>{t('gamesList.noGames')}</h4>
-            <p>{t('gamesList.startPlaying')}</p>
+            <h4>{t('gamesCalendar.noGames')}</h4>
+            <p>{t('gamesCalendar.startPlaying')}</p>
           </div>
         </div>
       </div>

--- a/src/components/SimpleLeaderboard.jsx
+++ b/src/components/SimpleLeaderboard.jsx
@@ -10,12 +10,13 @@ const SimpleLeaderboard = ({ gameData }) => {
   console.log('SimpleLeaderboard rendering...');
 
   let players = [];
+  let leaderboardData = null;
   let dataError = null;
 
   try {
-    const leaderboardData = getLeaderboardData(gameData);
+    leaderboardData = getLeaderboardData(gameData);
     console.log('Leaderboard data received:', leaderboardData);
-    
+
     if (leaderboardData && leaderboardData.players && Array.isArray(leaderboardData.players)) {
       players = leaderboardData.players;
       console.log('Players loaded:', players.length);
@@ -161,7 +162,7 @@ const SimpleLeaderboard = ({ gameData }) => {
             <div className="col-md-6">
               <small className="text-muted">
                 {t('leaderboard.totalPlayers')}: {players.length} | 
-                {t('leaderboard.totalGames')}: {Math.floor(players.reduce((sum, p) => sum + (p.gamesPlayed || 0), 0) / 2)}
+                {t('leaderboard.totalGames')}: {leaderboardData?.games?.length ?? 0}
               </small>
             </div>
             <div className="col-md-6 text-end">

--- a/src/components/SimpleTeamStatistics.jsx
+++ b/src/components/SimpleTeamStatistics.jsx
@@ -86,7 +86,7 @@ const SimpleTeamStatistics = ({ gameData }) => {
             </thead>
             <tbody>
               {teamStats.map((team, index) => {
-                const rank = index + 1;
+                const rank = team.rank ?? index + 1;
                 const players = team.players || [];
                 const gamesPlayed = team.gamesPlayed || 0;
                 const wins = team.wins || 0;
@@ -105,7 +105,7 @@ const SimpleTeamStatistics = ({ gameData }) => {
                         {players.map((player, playerIdx) => {
                           try {
                             // Use team ranking for avatar selection (top 3 teams get better avatars)
-                            const avatarRank = rank <= 3 ? 1 : 4; // Top 3 teams get happy, others get sad
+                            const avatarRank = rank <= 3 ? 1 : rank <= 9 ? 2 : 4;
                             return (
                               <div key={`${player}-${playerIdx}`} className="d-flex align-items-center me-2">
                                 <SimpleAvatarWithHover

--- a/src/test/components/Leaderboard.test.jsx
+++ b/src/test/components/Leaderboard.test.jsx
@@ -8,9 +8,16 @@ import SimpleLeaderboard from '../../components/SimpleLeaderboard';
 vi.mock('../../utils/dataUtils', () => ({
   getLeaderboardData: () => ({
     players: [
-      { id: 1, name: 'Jonas', cumulativeScore: 15, games: [{ gameId: 1, score: 3 }] },
-      { id: 2, name: 'Torben', cumulativeScore: 12, games: [{ gameId: 1, score: 2 }] },
-      { id: 3, name: 'Gitte', cumulativeScore: 10, games: [{ gameId: 1, score: 1 }] }
+      { id: 1, name: 'Jonas', cumulativeScore: 15, gamesPlayed: 2, games: [{ gameId: 1, score: 3 }, { gameId: 2, score: 2 }] },
+      { id: 2, name: 'Torben', cumulativeScore: 12, gamesPlayed: 2, games: [{ gameId: 1, score: 2 }, { gameId: 2, score: 1 }] },
+      { id: 3, name: 'Gitte', cumulativeScore: 10, gamesPlayed: 2, games: [{ gameId: 1, score: 1 }, { gameId: 2, score: 3 }] },
+      { id: 4, name: 'Anette', cumulativeScore: 9, gamesPlayed: 2, games: [{ gameId: 1, score: 3 }, { gameId: 2, score: 1 }] },
+      { id: 5, name: 'Lotte', cumulativeScore: 8, gamesPlayed: 2, games: [{ gameId: 1, score: 2 }, { gameId: 2, score: 2 }] },
+      { id: 6, name: 'Peter', cumulativeScore: 7, gamesPlayed: 2, games: [{ gameId: 1, score: 1 }, { gameId: 2, score: 3 }] }
+    ],
+    games: [
+      { gameId: 1, gameDate: '2026-01-01' },
+      { gameId: 2, gameDate: '2026-01-08' }
     ]
   })
 }));
@@ -52,11 +59,18 @@ describe('SimpleLeaderboard Component', () => {
 
   it('has table structure', () => {
     renderWithProviders(<SimpleLeaderboard />);
-    
+
     const table = screen.getByRole('table');
     const rows = screen.getAllByRole('row');
-    
+
     expect(table).toBeInTheDocument();
     expect(rows.length).toBeGreaterThan(1); // Header + data rows
+  });
+
+  it('displays the correct total games count from games array length', () => {
+    renderWithProviders(<SimpleLeaderboard />);
+    // Mock has 2 games. The footer small element must contain "2".
+    const footer = screen.getByText(/2/, { selector: 'small' });
+    expect(footer).toBeInTheDocument();
   });
 });

--- a/src/test/components/SimpleGamesCalendar.test.jsx
+++ b/src/test/components/SimpleGamesCalendar.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../utils/ThemeContext';
+import '../../utils/i18n';
+import SimpleGamesCalendar from '../../components/SimpleGamesCalendar';
+
+const mockGetGames = vi.fn();
+vi.mock('../../utils/dataUtils', () => ({
+  getGames: (...args) => mockGetGames(...args)
+}));
+
+const renderWithProviders = (component) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+describe('SimpleGamesCalendar – error state', () => {
+  beforeEach(() => {
+    mockGetGames.mockImplementation(() => { throw new Error('network error'); });
+  });
+
+  it('renders the error card without crashing', () => {
+    renderWithProviders(<SimpleGamesCalendar />);
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+  });
+});
+
+describe('SimpleGamesCalendar – empty state', () => {
+  beforeEach(() => {
+    mockGetGames.mockReturnValue([]);
+  });
+
+  it('renders the empty-state card without crashing', () => {
+    renderWithProviders(<SimpleGamesCalendar />);
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+  });
+
+  it('shows the no-games heading from gamesCalendar namespace', () => {
+    renderWithProviders(<SimpleGamesCalendar />);
+    // Danish: "Ingen spil fundet" — from gamesCalendar.noGames (added in locale files)
+    expect(screen.getByText('Ingen spil fundet')).toBeInTheDocument();
+  });
+
+  it('shows the start-playing prompt from gamesCalendar namespace', () => {
+    renderWithProviders(<SimpleGamesCalendar />);
+    // Danish: "Start med at spille nogle spil for at se kalenderen her!"
+    // gamesList.startPlaying ends "…historikken her!" — a different string.
+    // This test only passes once gamesCalendar.startPlaying is added to da.js.
+    expect(screen.getByText('Start med at spille nogle spil for at se kalenderen her!')).toBeInTheDocument();
+  });
+});

--- a/src/test/components/SimpleTeamStatistics.test.jsx
+++ b/src/test/components/SimpleTeamStatistics.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../utils/ThemeContext';
+import '../../utils/i18n';
+import SimpleTeamStatistics from '../../components/SimpleTeamStatistics';
+
+const getRankBasedAvatarMock = vi.fn((playerName) => `/assets/${playerName.toLowerCase()}/ok.png`);
+
+vi.mock('../../utils/simpleAvatarUtils', () => ({
+  getRankBasedAvatar: (playerName, rank) => getRankBasedAvatarMock(playerName, rank),
+  getPlayerAvatarOptions: () => [],
+  getPlayerAvatarPath: () => null,
+}));
+
+vi.mock('../../components/SimpleAvatarWithHover', () => ({
+  default: ({ playerName }) => <span data-testid={`avatar-${playerName}`} />,
+}));
+
+vi.mock('../../utils/dataUtils', () => ({
+  getTeamStatistics: () => [
+    { players: ['Jonas', 'Torben'], rank: 1, gamesPlayed: 5, wins: 3, totalPoints: 12, winRate: 60 },
+    { players: ['Gitte', 'Anette'], rank: 5, gamesPlayed: 5, wins: 2, totalPoints: 9, winRate: 40 },
+    { players: ['Lotte', 'Peter'], rank: 10, gamesPlayed: 5, wins: 0, totalPoints: 5, winRate: 0 },
+  ]
+}));
+
+const renderWithProviders = (component) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+describe('SimpleTeamStatistics – avatar rank selection', () => {
+  beforeEach(() => {
+    getRankBasedAvatarMock.mockClear();
+  });
+
+  it('passes avatarRank=1 (happy) for a team ranked 1st–3rd', () => {
+    renderWithProviders(<SimpleTeamStatistics />);
+    const callsForJonas = getRankBasedAvatarMock.mock.calls.filter(([name]) => name === 'Jonas');
+    expect(callsForJonas.length).toBeGreaterThan(0);
+    expect(callsForJonas[0][1]).toBe(1);
+  });
+
+  it('passes avatarRank=2 (ok/neutral) for a team ranked 4th–9th', () => {
+    renderWithProviders(<SimpleTeamStatistics />);
+    const callsForGitte = getRankBasedAvatarMock.mock.calls.filter(([name]) => name === 'Gitte');
+    expect(callsForGitte.length).toBeGreaterThan(0);
+    // Before the fix this will be 4 (sad). After the fix it must be 2 (ok).
+    expect(callsForGitte[0][1]).toBe(2);
+  });
+
+  it('passes avatarRank=4 (sad) for a team ranked 10th+', () => {
+    renderWithProviders(<SimpleTeamStatistics />);
+    const callsForLotte = getRankBasedAvatarMock.mock.calls.filter(([name]) => name === 'Lotte');
+    expect(callsForLotte.length).toBeGreaterThan(0);
+    expect(callsForLotte[0][1]).toBe(4);
+  });
+});

--- a/src/test/components/SimpleTeamStatistics.test.jsx
+++ b/src/test/components/SimpleTeamStatistics.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ThemeProvider } from '../../utils/ThemeContext';
 import '../../utils/i18n';
 import SimpleTeamStatistics from '../../components/SimpleTeamStatistics';

--- a/src/utils/locales/da.js
+++ b/src/utils/locales/da.js
@@ -263,6 +263,9 @@ export default {
     "title": "Spil Kalender",
     "timelineTitle": "Aktivitets Tidslinje",
     "error": "Spil Kalender Fejl",
+    "errorLoading": "Fejl ved indlæsning",
+    "noGames": "Ingen spil fundet",
+    "startPlaying": "Start med at spille nogle spil for at se kalenderen her!",
     "stats": {
       "totalGames": "Samlede Spil",
       "gameDays": "Spil Dage", 

--- a/src/utils/locales/en.js
+++ b/src/utils/locales/en.js
@@ -263,6 +263,9 @@ export default {
     "title": "Games Calendar",
     "timelineTitle": "Activity Timeline",
     "error": "Games Calendar Error",
+    "errorLoading": "Error loading",
+    "noGames": "No games found",
+    "startPlaying": "Start playing some games to see the calendar here!",
     "stats": {
       "totalGames": "Total Games",
       "gameDays": "Game Days", 


### PR DESCRIPTION
## Summary

- **SimpleLeaderboard**: footer total-games count now uses `leaderboardData.games.length` instead of dividing the sum of per-player `gamesPlayed` by 2 (was 3× inflated)
- **SimpleGamesCalendar**: error and empty-state messages now use `gamesCalendar.*` translation keys instead of borrowing `gamesList.*` keys from the wrong component
- **SimpleTeamStatistics**: avatar rank selection now applies three bands (happy 1–3, neutral 4–9, sad 10+) instead of the previous two-band mapping (happy 1–3, sad 4+)

## Test Plan

- [x] `src/test/components/Leaderboard.test.jsx` — updated mock includes `games` array; new test verifies footer shows `games.length` count
- [x] `src/test/components/SimpleGamesCalendar.test.jsx` — new file; tests assert calendar-specific Danish strings appear (distinct from `gamesList` strings)
- [x] `src/test/components/SimpleTeamStatistics.test.jsx` — new file; tests verify `avatarRank` passed to `getRankBasedAvatar` for each of the three rank bands
- [x] Full suite: 157 tests across 22 files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)