### PR TITLE
fix: correct inaccuracies flagged in PR #145 and #146 reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A single-page React application for tracking and visualising tournament statisti
 
 ## Getting Started
 
-Requires **Node v22** (see `.nvmrc`).
+Node v22 recommended for local development (see `.nvmrc`); Node 20 and 22 are both supported (see `package.json` `engines` and CI matrix).
 
 ```bash
 npm install

--- a/docs/DATA_UPDATE.md
+++ b/docs/DATA_UPDATE.md
@@ -2,18 +2,21 @@
 
 ## Adding a Game Result
 
-Game results live in `src/data/games.json` (current season) and `src/data/games_YYYY.json` (past seasons).
+Game results live in `src/data/games.json` (2025 season) and `src/data/games_2026.json` (2026 season).
 
-Each entry in the `games` array follows this format:
+Each entry in the array follows this format:
 
 ```json
 {
   "gameId": 42,
   "gameDate": "2026-06-15",
-  "teams": [
-    { "players": ["Jonas", "Torben"], "score": 3, "place": 1 },
-    { "players": ["Gitte", "Anette"], "score": 2, "place": 2 },
-    { "players": ["Lotte", "Peter"], "score": 1, "place": 3 }
+  "players": [
+    { "name": "Jonas", "score": 3 },
+    { "name": "Torben", "score": 3 },
+    { "name": "Gitte", "score": 2 },
+    { "name": "Anette", "score": 2 },
+    { "name": "Lotte", "score": 1 },
+    { "name": "Peter", "score": 1 }
   ]
 }
 ```
@@ -22,10 +25,9 @@ Rules:
 
 - `gameId` must be unique across all entries in the file.
 - `gameDate` is `YYYY-MM-DD`.
-- Every game has exactly 3 teams of exactly 2 players.
-- All 6 players (Jonas, Torben, Gitte, Anette, Lotte, Peter) participate in every game.
-- `place` values must be 1, 2, 3 — one team per place.
-- `score` values must be 3, 2, 1 corresponding to places 1, 2, 3.
+- Every game has exactly 6 players — all six (Jonas, Torben, Gitte, Anette, Lotte, Peter) participate in every game.
+- Players with the same `score` are on the same team. Teams are derived automatically by `processGamesData` in `src/utils/dataUtils.js` — there are no `teams` or `place` fields in the raw data.
+- Score values must be 3, 2, or 1. Two players share each score value (three teams of two).
 
 After editing the JSON, run `npm test` to verify the data parses correctly.
 
@@ -35,37 +37,31 @@ A new season requires changes in three places:
 
 ### 1. Create the data file
 
-Copy the current `src/data/games.json` structure and save results to `src/data/games_YYYY.json`
-(e.g. `src/data/games_2027.json`). The file must export or contain a valid JSON array of game objects.
+Create `src/data/games_YYYY.json` (e.g. `src/data/games_2027.json`) containing an array of game objects in the format shown above. Start with an empty array `[]` and populate it as games are played.
 
 ### 2. Register the data file in `dataUtils.js`
 
-In `src/utils/dataUtils.js`, add the new year to the `GAMES_DATA_BY_YEAR` mapping:
+In `src/utils/dataUtils.js`, add the new year to the import and the `GAMES_DATA_BY_YEAR` mapping:
 
 ```javascript
-// Before
-const GAMES_DATA_BY_YEAR = {
-  2025: games2025Data,
-  2026: gamesData,
-};
+// Add import at the top
+import gamesData2027 from '../data/games_2027.json';
 
-// After
-import games2027Data from '../data/games_2027.json';
-
+// Add to the mapping
 const GAMES_DATA_BY_YEAR = {
-  2025: games2025Data,
-  2026: gamesData,
-  2027: games2027Data,
+  2025: gamesData2025,
+  2026: gamesData2026,
+  2027: gamesData2027,
 };
 ```
 
 ### 3. Add the year to `YearContext.jsx`
 
-In `src/utils/YearContext.jsx`, add the year to `AVAILABLE_YEARS` and update `MOST_RECENT_YEAR`:
+In `src/utils/YearContext.jsx`, add the year to `AVAILABLE_YEARS`:
 
 ```javascript
 export const AVAILABLE_YEARS = [2025, 2026, 2027];
-export const MOST_RECENT_YEAR = 2027;
+export const MOST_RECENT_YEAR = Math.max(...AVAILABLE_YEARS);
 ```
 
-After these changes, the year selector in the navbar will include the new season and it will be selected by default.
+`MOST_RECENT_YEAR` is derived automatically — only `AVAILABLE_YEARS` needs updating. The year selector in the navbar will include the new season and select it by default.

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -34,7 +34,7 @@ The Partners Competition App has comprehensive logging using Logtail/Better Stac
 ### User Interactions
 
 - **Theme Toggle** (SimpleThemeToggle.jsx): Logs theme changes (dark/light mode)
-- **Language Selector** (LanguageSelector.js): Logs language changes (English/Danish)
+- **Language Selector** (LanguageSelector.jsx): Logs language changes (English/Danish)
 - **Avatar Interactions** (SimpleAvatarWithHover.jsx): Logs hover events with position data
 
 ### Error Handling
@@ -95,7 +95,7 @@ All logs include:
 
 - `/src/App.jsx` - Application lifecycle logging
 - `/src/components/SimpleThemeToggle.jsx` - Theme change logging
-- `/src/components/LanguageSelector.js` - Language change logging
+- `/src/components/LanguageSelector.jsx` - Language change logging
 - `/src/components/SimpleAvatarWithHover.jsx` - Avatar interaction logging
 - `/src/components/SimpleGamesList.jsx` - Data loading and error logging
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,7 +12,7 @@ npm run test:coverage      # Coverage report
 Run a single test file:
 
 ```bash
-npx vitest run src/test/components/SimpleLeaderboard.test.jsx
+npx vitest run src/test/components/Leaderboard.test.jsx
 ```
 
 ## Test Structure

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -34,6 +34,10 @@ Improvements identified from a codebase review on 2026-06-12.
 
 - [x] **`src/test/utilities.test.js` reimplements `getPlayerAvatarPath` inline** instead of importing from `simpleAvatarUtils`. It calls the reimplemented version with two arguments, which the real function does not accept, so the tests are not exercising the actual code.
 
+- [ ] **i18n language not pinned in component test files** (`src/test/components/SimpleGamesList.test.jsx`, `src/test/components/SimplePlayerPerformance.test.jsx`) — tests assert Danish strings but never explicitly set the language. If another test file changes the shared i18n instance's language first, these tests become order-dependent and may fail. Add `beforeEach(() => i18n.changeLanguage('da'))` to each file.
+
+- [ ] **`console.log` noise in `utilities.test.js`** — `getPlayerAvatarPath` emits `console.log` for both valid and invalid inputs, so the test suite produces noisy output during `vitest run`. Stub `console.log` in a `beforeEach` in that file (similar to how `console.error` is stubbed elsewhere).
+
 ## Accessibility
 
 - [ ] **Progress bars lack ARIA attributes** — `SimpleSummaryCards` and `SimplePlayerPerformance` render `<div class="progress-bar">` without `role="progressbar"`, `aria-valuenow`, `aria-valuemin`, or `aria-valuemax`. Bootstrap requires these for screen reader support.


### PR DESCRIPTION
## Summary

Fixes confirmed inaccuracies identified in Copilot review comments on the two recently merged PRs.

### `docs/DATA_UPDATE.md` (PR #146 — 3 issues)
- **Wrong JSON format**: documented a `teams`/`place` structure that doesn't exist. Actual format is a flat `players` array with `name` and `score`; teams are derived by `processGamesData` in `dataUtils.js`
- **Wrong variable names**: `games2025Data`/`gamesData` → `gamesData2025`/`gamesData2026` (matching actual imports in `dataUtils.js`)
- **Unnecessary step**: removed manual `MOST_RECENT_YEAR` update — it is `Math.max(...AVAILABLE_YEARS)` and updates automatically

### `docs/TESTING.md` (PR #146)
- Wrong test filename in example command: `SimpleLeaderboard.test.jsx` → `Leaderboard.test.jsx`

### `docs/LOGGING.md` (PR #146 — 2 instances)
- `LanguageSelector.js` → `LanguageSelector.jsx` (both occurrences)

### `README.md` (PR #146)
- `.nvmrc` does exist (v22.16.0), but Node 20 is also supported per `package.json` engines and CI matrix. Clarified both

### `docs/TODO.md`
- Added two test quality items from PR #145 Copilot review (not doc fixes, so tracked for follow-up rather than fixed immediately):
  - i18n language not pinned in `SimpleGamesList.test.jsx` and `SimplePlayerPerformance.test.jsx` — order-dependent failure risk
  - `console.log` noise in `utilities.test.js` — `getPlayerAvatarPath` emits logs for every call

## Test plan

- [ ] `npm test` passes (no test changes in this PR)
- [ ] `docs/DATA_UPDATE.md` JSON example matches `src/data/games_2026.json` actual format
- [ ] `docs/DATA_UPDATE.md` variable names match `src/utils/dataUtils.js` imports
- [ ] `docs/LOGGING.md` filename references are all `.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)