### PR TITLE
Add second match results for 2026-06-27

### DIFF
--- a/src/data/games.json
+++ b/src/data/games.json
@@ -568,5 +568,35 @@
         "score": 1
       }
     ]
+  },
+  {
+    "gameId": 20,
+    "gameDate": "2026-06-27",
+    "players": [
+      {
+        "name": "Gitte",
+        "score": 3
+      },
+      {
+        "name": "Jonas",
+        "score": 3
+      },
+      {
+        "name": "Torben",
+        "score": 2
+      },
+      {
+        "name": "Anette",
+        "score": 2
+      },
+      {
+        "name": "Peter",
+        "score": 1
+      },
+      {
+        "name": "Lotte",
+        "score": 1
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
Add second match results for today (2026-06-27).

**Match Results:**
- 1st place (3 pts): Gitte & Jonas
- 2nd place (2 pts): Torben & Anette
- 3rd place (1 pt): Peter & Lotte

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPv2bdE7PLhne9JDajRif)_