### PR TITLE
chore: tune dependabot grouping to isolate major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,17 @@ updates:
     # Check for updates once a week
     schedule:
       interval: "weekly"
-  
+    cooldown:
+      default-days: 7
+    groups:
+      major-updates:
+        update-types:
+          - "major"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   # Regular npm version updates: grouped into fewer PRs on a monthly schedule
   # Note: cooldown applies to version updates only
   - package-ecosystem: "npm"
@@ -20,9 +30,13 @@ updates:
     cooldown:
       default-days: 4
     groups:
-      # Regular updates: bundle all version bumps into a single grouped PR
+      # Regular updates: bundle minor/patch version bumps into a single grouped PR
+      # Major bumps arrive as individual PRs (no group catches them)
       npm-regular-updates:
         applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,13 @@ updates:
       default-days: 7
     groups:
       major-updates:
+        patterns:
+          - "*"
         update-types:
           - "major"
       minor-and-patch:
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

- The `npm` dependabot group (`npm-regular-updates`) previously used `patterns: ['*']` with no `update-types` constraint, which meant it batched **all** version bumps — including majors — into a single grouped PR. This caused major upgrades (e.g. ESLint 9→10) to land silently alongside safe minor/patch updates.
- `update-types: [minor, patch]` has been added to the existing group so majors now arrive as **individual, clearly-labelled PRs** that require deliberate review. No second group was added.
- The `github-actions` entry now has a `cooldown: default-days: 7` and two groups: `major-updates` (major only) and `minor-and-patch` (minor + patch), matching the same isolation principle.

## Test plan

- [ ] Verify `.github/dependabot.yml` passes YAML lint (`ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml')"`)
- [ ] Confirm no other files were changed in this PR
- [ ] After merge, check that the next dependabot npm run opens separate PRs for any major bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)