### PR TITLE
Fix high severity brace-expansion DoS vulnerability (npm audit)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,11 +2074,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -2123,14 +2126,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2292,13 +2297,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4618,16 +4616,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "overrides": {
     "parse5": "^7.2.3",
     "flatted": "^3.4.2",
-    "@exodus/bytes": "1.15.0"
+    "@exodus/bytes": "1.15.0",
+    "minimatch": "^10.2.6"
   }
 }


### PR DESCRIPTION
## Summary
- `npm audit` was reporting a high-severity DoS vulnerability (GHSA-mh99-v99m-4gvg) in `brace-expansion`, failing the `security` job in CI (`npm audit --audit-level=moderate`).
- Root cause: `eslint-plugin-react@7.37.5` pins `minimatch@^3.1.2`, which pins `brace-expansion@^1.1.7` — a version with no patched release available (the advisory's fix only landed in `brace-expansion@5.0.8`, across every prior major line).
- A direct override of `brace-expansion` to `5.0.8` was tried first but breaks: that release changed its export from a plain function to `{ expand, ... }`, which `minimatch@3.x` calls as a function directly (`TypeError: expand is not a function`) — this broke `npm run lint`.
- Fix: override `minimatch` itself to `^10.2.6` via `package.json` `overrides` (same pattern already used for `parse5`/`flatted`/`@exodus/bytes`). `minimatch@10.2.6` already depends on the patched `brace-expansion@^5.0.8` and is written against its new export shape. It also dedupes with `eslint`'s own internal `minimatch` usage, so there's only one copy in the tree.
- This only affects dev tooling (`eslint`/`eslint-plugin-react`) — no runtime/application dependency is involved.

## Test plan
- [x] `npm audit` → 0 vulnerabilities (was 6 high)
- [x] Clean `npm ci` (matches CI) → 0 vulnerabilities
- [x] `npm run lint` → same 44 pre-existing `no-console` warnings, 0 errors (previously crashed with the direct `brace-expansion` override)
- [x] `npm run test:run` → 231/231 tests pass, 36/36 files
- [x] `npm run build` → succeeds, output unchanged in shape
- [ ] CI `security` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)