### PR TITLE
docs: add session follow-ups to TODO.md

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -101,3 +101,37 @@ Findings from a documentation review on 2026-06-12.
 - [x] **No data update guide** — created `docs/DATA_UPDATE.md`.
 
 - [x] **No contributing guide** — created `docs/CONTRIBUTING.md`.
+
+## Session Follow-ups (2026-08-01)
+
+Outstanding items from a Dependabot PR review/merge session. The session's
+git proxy blocks tag pushes and branch deletion, so these need a human with
+push access.
+
+- [ ] **Push the summer-tournament-2026 tag** — marks the commit that
+  concluded the 2026 summer tournament (finalized dates for games 35-40,
+  last edit to `tournament_summer_2026.json`).
+
+  ```bash
+  git tag summer-tournament-2026 501f404350b6a74aa709bec2aae01d58ab83e430
+  git push origin summer-tournament-2026
+  ```
+
+- [ ] **Delete stray branch `probe-test-delete-me`** — created while probing
+  push permissions on the git proxy; not needed.
+
+  ```bash
+  git push origin --delete probe-test-delete-me
+  ```
+
+- [ ] **PR #168 blocked: eslint 9.39.5 → 10.8.0**
+  (<https://github.com/jonasbn/partners-competition-app/pull/168>) — ESLint
+  10 removed `context.getFilename()` from the rule API.
+  `eslint-plugin-react@7.37.5` (latest published) still depends on it and
+  caps its peer dependency at `eslint: ^9.7`; no ESLint-10-compatible
+  release exists yet. Reproduced locally (`npm run lint` throws
+  `TypeError: contextOrFilename.getFilename is not a function` in
+  `src/App.jsx`); the PR's own CI (`Lint and Format Check`, `test (24.x)`)
+  is already red for the same reason. Comment left on the PR explaining
+  this. Re-trigger once `eslint-plugin-react` ships support, e.g. by
+  commenting `@dependabot recreate` on the PR.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -135,3 +135,19 @@ push access.
   is already red for the same reason. Comment left on the PR explaining
   this. Re-trigger once `eslint-plugin-react` ships support, e.g. by
   commenting `@dependabot recreate` on the PR.
+
+- [ ] **Cut a release covering the security fix and this session's
+  maintenance PRs** — spans the brace-expansion DoS fix (PR #165, merged
+  2026-07-30) through the Dependabot bumps merged this session: #166
+  (npm-regular-updates group: react-i18next, @vitejs/plugin-react-swc,
+  globals, vite), #167 (jsdom 29→30), and #169
+  (@testing-library/jest-dom 6→7). Latest existing tag is `1.2.0`; next
+  would be `1.3.0` per the repo's semver tagging convention.
+
+  ```bash
+  git tag 1.3.0
+  git push origin 1.3.0
+  ```
+
+  Then draft a GitHub release from the tag summarizing the security fix and
+  dependency bumps.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -151,3 +151,13 @@ push access.
 
   Then draft a GitHub release from the tag summarizing the security fix and
   dependency bumps.
+
+- [ ] **Push the tenerife-tournament-2025 tag** — marks the commit that
+  concluded the 2025 season/Tenerife tournament in `games.json` (games
+  12-18, last game dated 2025-11-21). Named to match the
+  `summer-tournament-2026` convention (`<name>-tournament-<year>`).
+
+  ```bash
+  git tag tenerife-tournament-2025 4b0f4e88d53ce1c65728a5bf715aa61a1dfceaf9
+  git push origin tenerife-tournament-2025
+  ```

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,7 +26,7 @@ Improvements identified from a codebase review on 2026-06-12.
 
 - [ ] **`summary.*` i18n namespace is orphaned** — both locale files define a `summary` top-level namespace (`leadingPlayer`, `mostWinningTeam`, `teamCoverage`, etc.) that no component uses; components use `summaryCards.*` instead. These keys are only referenced in two test files. Rename to match component usage or remove.
 
-- [ ] **No ESLint configuration** — the quality CI workflow already acknowledges the gap. Adding `eslint` with `eslint-plugin-react` and `eslint-plugin-react-hooks` would catch most of the issues above automatically.
+- [x] **No ESLint configuration** — added (`eslint.config.js`, `eslint-plugin-react`, `eslint-plugin-react-hooks`); this note was stale.
 
 ## Test Coverage
 
@@ -106,58 +106,35 @@ Findings from a documentation review on 2026-06-12.
 
 Outstanding items from a Dependabot PR review/merge session. The session's
 git proxy blocks tag pushes and branch deletion, so these need a human with
-push access.
+push access. Resolved 2026-08-09.
 
-- [ ] **Push the summer-tournament-2026 tag** — marks the commit that
+- [x] **Push the summer-tournament-2026 tag** — marks the commit that
   concluded the 2026 summer tournament (finalized dates for games 35-40,
-  last edit to `tournament_summer_2026.json`).
+  last edit to `tournament_summer_2026.json`). Pushed 2026-08-09, pointing
+  at `501f404`.
 
-  ```bash
-  git tag summer-tournament-2026 501f404350b6a74aa709bec2aae01d58ab83e430
-  git push origin summer-tournament-2026
-  ```
+- [x] **Delete stray branch `probe-test-delete-me`** — created while probing
+  push permissions on the git proxy; not needed. Deleted 2026-08-09.
 
-- [ ] **Delete stray branch `probe-test-delete-me`** — created while probing
-  push permissions on the git proxy; not needed.
-
-  ```bash
-  git push origin --delete probe-test-delete-me
-  ```
-
-- [ ] **PR #168 blocked: eslint 9.39.5 → 10.8.0**
+- [x] **PR #168 blocked: eslint 9.39.5 → 10.8.0**
   (<https://github.com/jonasbn/partners-competition-app/pull/168>) — ESLint
   10 removed `context.getFilename()` from the rule API.
   `eslint-plugin-react@7.37.5` (latest published) still depends on it and
   caps its peer dependency at `eslint: ^9.7`; no ESLint-10-compatible
-  release exists yet. Reproduced locally (`npm run lint` throws
-  `TypeError: contextOrFilename.getFilename is not a function` in
-  `src/App.jsx`); the PR's own CI (`Lint and Format Check`, `test (24.x)`)
-  is already red for the same reason. Comment left on the PR explaining
-  this. Re-trigger once `eslint-plugin-react` ships support, e.g. by
-  commenting `@dependabot recreate` on the PR.
+  release exists yet, confirmed against the upstream tracking issue
+  ([jsx-eslint/eslint-plugin-react#3977](https://github.com/jsx-eslint/eslint-plugin-react/issues/3977)).
+  Closed 2026-08-09 with `@dependabot ignore this major version` so it
+  won't keep reopening; re-trigger once `eslint-plugin-react` ships
+  ESLint 10 support.
 
-- [ ] **Cut a release covering the security fix and this session's
-  maintenance PRs** — spans the brace-expansion DoS fix (PR #165, merged
-  2026-07-30) through the Dependabot bumps merged this session: #166
-  (npm-regular-updates group: react-i18next, @vitejs/plugin-react-swc,
-  globals, vite), #167 (jsdom 29→30), and #169
-  (@testing-library/jest-dom 6→7). Latest existing tag is `1.2.0`; next
-  would be `1.3.0` per the repo's semver tagging convention.
+- [x] **Cut a release covering the security fix and this session's
+  maintenance PRs** — released as `1.3.0` (draft) on 2026-08-09. Notes were
+  expanded beyond the security fix (PR #165) and Dependabot bumps
+  (#166, #167, #169) to also cover everything else merged since `1.2.0`:
+  the full Summer Tournament 2026 feature and the Node.js 24 upgrade.
 
-  ```bash
-  git tag 1.3.0
-  git push origin 1.3.0
-  ```
-
-  Then draft a GitHub release from the tag summarizing the security fix and
-  dependency bumps.
-
-- [ ] **Push the tenerife-tournament-2025 tag** — marks the commit that
+- [x] **Push the tenerife-tournament-2025 tag** — marks the commit that
   concluded the 2025 season/Tenerife tournament in `games.json` (games
   12-18, last game dated 2025-11-21). Named to match the
-  `summer-tournament-2026` convention (`<name>-tournament-<year>`).
-
-  ```bash
-  git tag tenerife-tournament-2025 4b0f4e88d53ce1c65728a5bf715aa61a1dfceaf9
-  git push origin tenerife-tournament-2025
-  ```
+  `summer-tournament-2026` convention (`<name>-tournament-<year>`). Pushed
+  2026-08-09, pointing at `4b0f4e88`.


### PR DESCRIPTION
## Summary

- Track outstanding items from a Dependabot PR review/merge session in `docs/TODO.md`, appended as a new "Session Follow-ups (2026-08-01)" section in the existing checkbox style.
- Covers three items that need a human with unrestricted push access: pushing the `summer-tournament-2026` tag (commit `501f404`, the last edit to `tournament_summer_2026.json` before this session's PRs), deleting a stray probe branch left over from testing git push permissions, and the status of PR #168 (eslint 9→10 bump blocked on `eslint-plugin-react` not yet supporting ESLint 10).

## Test plan

- [x] Documentation-only change; no code affected.
- [ ] Verify markdownlint passes in CI (`.markdownlint.json` rules).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhhHpQgNHp8KJaWCFx2Q7F)_